### PR TITLE
2.0update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Indel discovery in human whole-genome sequencing data.
 - Samtools 1.3.1
 - Python 2.7
 - Cromwell version support 
-  - Successfully tested on v47
+  - Successfully tested on v51
   - Does not work on versions < v23 due to output syntax
 
 ### Important Notes :
@@ -43,7 +43,7 @@ view the following tutorial [(How to) Execute Workflows from the gatk-workflows 
 - The following material is provided by the Data Science Platforum group at the Broad Institute. Please direct any questions or concerns to one of our forum sites : [GATK](https://gatk.broadinstitute.org/hc/en-us/community/topics) or [Terra](https://support.terra.bio/hc/en-us/community/topics/360000500432).
 
 ### LICENSING :
-Copyright Broad Institute, 2019 | BSD-3
+Copyright Broad Institute, 2020 | BSD-3
 This script is released under the WDL open source code license (BSD-3) (full license text at https://github.com/openwdl/wdl/blob/master/LICENSE). Note however that the programs it calls may be subject to different licenses. Users are responsible for checking that they are authorized to run all programs before running this script.
 - [GATK](https://software.broadinstitute.org/gatk/download/licensing.php)
 - [BWA](http://bio-bwa.sourceforge.net/bwa.shtml#13)

--- a/WholeGenomeGermlineSingleSample.inputs.json
+++ b/WholeGenomeGermlineSingleSample.inputs.json
@@ -33,24 +33,20 @@
   },
 
   "WholeGenomeGermlineSingleSample.references": {
-    "fingerprint_genotypes_file": "gs://dsde-data-na12878-public/NA12878.hg38.reference.fingerprint.vcf",
-    "fingerprint_genotypes_index": "gs://dsde-data-na12878-public/NA12878.hg38.reference.fingerprint.vcf.idx",
     "contamination_sites_ud": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.contam.UD",
     "contamination_sites_bed": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.contam.bed",
     "contamination_sites_mu": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.contam.mu",
     "calling_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list",
-    "haplotype_scatter_count": 10,
-    "break_bands_at_multiples_of": 100000,
-    "reference_fasta" : {
-        "ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
-        "ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
-        "ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-        "ref_alt": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-        "ref_sa": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-        "ref_amb": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb",
-        "ref_bwt": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-        "ref_ann": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-        "ref_pac": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac"
+    "reference_fasta": {
+      "ref_dict": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict",
+      "ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+      "ref_fasta_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+      "ref_alt": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
+      "ref_sa": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
+      "ref_amb": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb",
+      "ref_bwt": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
+      "ref_ann": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
+      "ref_pac": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac"
     },
     "known_indels_sites_vcfs": [
       "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
@@ -62,11 +58,17 @@
     ],
     "dbsnp_vcf": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
     "dbsnp_vcf_index": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
-    "evaluation_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list"
+    "evaluation_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list",
+    "haplotype_database_file": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt"
   },
 
+  "WholeGenomeGermlineSingleSample.scatter_settings": {
+    "haplotype_scatter_count": 50,
+    "break_bands_at_multiples_of": 1000000
+  },
+
+  "WholeGenomeGermlineSingleSample.fingerprint_genotypes_file": "gs://dsde-data-na12878-public/NA12878.hg38.reference.fingerprint.vcf",
   "WholeGenomeGermlineSingleSample.wgs_coverage_interval_list": "gs://gcp-public-data--broad-references/hg38/v0/wgs_coverage_regions.hg38.interval_list",
-  "WholeGenomeGermlineSingleSample.haplotype_database_file": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.haplotype_database.txt",
 
   "WholeGenomeGermlineSingleSample.papi_settings": {
     "preemptible_tries": 3,

--- a/structs/DNASeqStructs.wdl
+++ b/structs/DNASeqStructs.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 struct SampleAndUnmappedBams {
   String base_file_name
-  String final_gvcf_base_name
+  String? final_gvcf_base_name
   Array[File] flowcell_unmapped_bams
   String sample_name
   String unmapped_bam_suffix
@@ -20,17 +20,11 @@ struct ReferenceFasta {
   File ref_pac
 }
 
-struct GermlineSingleSampleReferences {
-  File? fingerprint_genotypes_file
-  File? fingerprint_genotypes_index
-
+struct DNASeqSingleSampleReferences {
   File contamination_sites_ud
   File contamination_sites_bed
   File contamination_sites_mu
   File calling_interval_list
-
-  Int haplotype_scatter_count
-  Int break_bands_at_multiples_of
 
   ReferenceFasta reference_fasta
 
@@ -41,6 +35,13 @@ struct GermlineSingleSampleReferences {
   File dbsnp_vcf_index
 
   File evaluation_interval_list
+
+  File haplotype_database_file
+}
+
+struct VariantCallingScatterSettings {
+   Int haplotype_scatter_count
+   Int break_bands_at_multiples_of
 }
 
 struct ExomeGermlineSingleSampleOligos {

--- a/tasks/AggregatedBamQC.wdl
+++ b/tasks/AggregatedBamQC.wdl
@@ -16,7 +16,7 @@ version 1.0
 ## licensing information pertaining to the included programs.
 
 import "./Qc.wdl" as QC
-import "../structs/GermlineStructs.wdl"
+import "../structs/DNASeqStructs.wdl"
 
 # WORKFLOW DEFINITION
 workflow AggregatedBamQC {
@@ -26,9 +26,11 @@ input {
     String base_name
     String sample_name
     String recalibrated_bam_base_name
-    File? haplotype_database_file
-    GermlineSingleSampleReferences references
+    File haplotype_database_file
+    DNASeqSingleSampleReferences references
     PapiSettings papi_settings
+    File? fingerprint_genotypes_file
+    File? fingerprint_genotypes_index
   }
 
   # QC the final BAM (consolidated after scattered BQSR)
@@ -55,15 +57,15 @@ input {
       preemptible_tries = papi_settings.agg_preemptible_tries
   }
 
-  if (defined(haplotype_database_file) && defined(references.fingerprint_genotypes_file)) {
+  if (defined(haplotype_database_file) && defined(fingerprint_genotypes_file)) {
     # Check the sample BAM fingerprint against the sample array
     call QC.CheckFingerprint as CheckFingerprint {
       input:
         input_bam = base_recalibrated_bam,
         input_bam_index = base_recalibrated_bam_index,
         haplotype_database_file = haplotype_database_file,
-        genotypes = references.fingerprint_genotypes_file,
-        genotypes_index = references.fingerprint_genotypes_index,
+        genotypes = fingerprint_genotypes_file,
+        genotypes_index = fingerprint_genotypes_index,
         output_basename = base_name,
         sample = sample_name,
         preemptible_tries = papi_settings.agg_preemptible_tries

--- a/tasks/Alignment.wdl
+++ b/tasks/Alignment.wdl
@@ -15,7 +15,7 @@ version 1.0
 ## page at https://hub.docker.com/r/broadinstitute/genomes-in-the-cloud/ for detailed
 ## licensing information pertaining to the included programs.
 
-import "../structs/GermlineStructs.wdl"
+import "../structs/DNASeqStructs.wdl"
 
 # Get version of BWA
 task GetBwaVersion {
@@ -50,6 +50,7 @@ task SamToFastqAndBwaMemAndMba {
 
     Int compression_level
     Int preemptible_tries
+    Boolean hard_clip_reads = false
   }
 
   Float unmapped_bam_size = size(input_bam, "GiB")
@@ -91,6 +92,8 @@ task SamToFastqAndBwaMemAndMba {
         IS_BISULFITE_SEQUENCE=false \
         ALIGNED_READS_ONLY=false \
         CLIP_ADAPTERS=false \
+        ~{true='CLIP_OVERLAPPING_READS=true' false="" hard_clip_reads} \
+        ~{true='CLIP_OVERLAPPING_READS_OPERATOR=H' false="" hard_clip_reads} \
         MAX_RECORDS_IN_RAM=2000000 \
         ADD_MATE_CIGAR=true \
         MAX_INSERTIONS_OR_DELETIONS=-1 \
@@ -113,7 +116,7 @@ task SamToFastqAndBwaMemAndMba {
     fi
   >>>
   runtime {
-    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.3-1564508330"
+    docker: "us.gcr.io/broad-gotc-prod/genomes-in-the-cloud:2.4.3-1564508330" # TODO: update docker to use the new Picard options
     preemptible: preemptible_tries
     memory: "14 GiB"
     cpu: "16"

--- a/tasks/BamProcessing.wdl
+++ b/tasks/BamProcessing.wdl
@@ -273,12 +273,16 @@ task ApplyBQSR {
     String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.0.10.1"
     Int memory_multiplier = 1
     Int additional_disk = 20
+    Boolean bin_base_qualities = true
+    Boolean somatic = false
   }
 
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
   Int disk_size = ceil((size(input_bam, "GiB") * 3 / bqsr_scatter) + ref_size) + additional_disk
 
   Int memory_size = ceil(3500 * memory_multiplier)
+
+  Boolean bin_somatic_base_qualities = bin_base_qualities && somatic
 
   parameter_meta {
     input_bam: {
@@ -298,9 +302,11 @@ task ApplyBQSR {
       --use-original-qualities \
       -O ~{output_bam_basename}.bam \
       -bqsr ~{recalibration_report} \
-      --static-quantized-quals 10 \
-      --static-quantized-quals 20 \
-      --static-quantized-quals 30 \
+      ~{true='--static-quantized-quals 10' false='' bin_base_qualities} \
+      ~{true='--static-quantized-quals 20' false='' bin_base_qualities} \
+      ~{true='--static-quantized-quals 30' false='' bin_base_qualities} \
+      ~{true='--static-quantized-quals 40' false='' bin_somatic_base_qualities} \
+      ~{true='--static-quantized-quals 50' false='' bin_somatic_base_qualities} \
       -L ~{sep=" -L " sequence_group_interval}
   }
   runtime {

--- a/tasks/SplitLargeReadGroup.wdl
+++ b/tasks/SplitLargeReadGroup.wdl
@@ -18,7 +18,7 @@ version 1.0
 import "./Alignment.wdl" as Alignment
 import "./BamProcessing.wdl" as Processing
 import "./Utilities.wdl" as Utils
-import "../structs/GermlineStructs.wdl" as Structs
+import "../structs/DNASeqStructs.wdl" as Structs
 
 workflow SplitLargeReadGroup {
 
@@ -37,6 +37,7 @@ workflow SplitLargeReadGroup {
     Int compression_level
     Int preemptible_tries
     Int reads_per_file = 48000000
+    Boolean hard_clip_reads = false
   }
 
   call Alignment.SamSplitter as SamSplitter {
@@ -59,7 +60,8 @@ workflow SplitLargeReadGroup {
         reference_fasta = reference_fasta,
         bwa_version = bwa_version,
         compression_level = compression_level,
-        preemptible_tries = preemptible_tries
+        preemptible_tries = preemptible_tries,
+        hard_clip_reads = hard_clip_reads
     }
 
     Float current_mapped_size = size(SamToFastqAndBwaMemAndMba.output_bam, "GiB")

--- a/tasks/UnmappedBamToAlignedBam.wdl
+++ b/tasks/UnmappedBamToAlignedBam.wdl
@@ -21,14 +21,14 @@ import "./SplitLargeReadGroup.wdl" as SplitRG
 import "./Qc.wdl" as QC
 import "./BamProcessing.wdl" as Processing
 import "./Utilities.wdl" as Utils
-import "../structs/GermlineStructs.wdl" as Structs
+import "../structs/DNASeqStructs.wdl" as Structs
 
 # WORKFLOW DEFINITION
 workflow UnmappedBamToAlignedBam {
 
   input {
     SampleAndUnmappedBams sample_and_unmapped_bams
-    GermlineSingleSampleReferences references
+    DNASeqSingleSampleReferences references
     PapiSettings papi_settings
 
     File contamination_sites_ud
@@ -36,9 +36,12 @@ workflow UnmappedBamToAlignedBam {
     File contamination_sites_mu
 
     String cross_check_fingerprints_by
-    File? haplotype_database_file
+    File haplotype_database_file
     Float lod_threshold
     String recalibrated_bam_basename
+    Boolean hard_clip_reads = false
+    Boolean bin_base_qualities = true
+    Boolean somatic = false
   }
 
   Float cutoff_for_large_rg_in_gb = 20.0
@@ -79,7 +82,8 @@ workflow UnmappedBamToAlignedBam {
           output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
           reference_fasta = references.reference_fasta,
           compression_level = compression_level,
-          preemptible_tries = papi_settings.preemptible_tries
+          preemptible_tries = papi_settings.preemptible_tries,
+          hard_clip_reads = hard_clip_reads
       }
     }
 
@@ -93,7 +97,8 @@ workflow UnmappedBamToAlignedBam {
           reference_fasta = references.reference_fasta,
           bwa_version = GetBwaVersion.bwa_version,
           compression_level = compression_level,
-          preemptible_tries = papi_settings.preemptible_tries
+          preemptible_tries = papi_settings.preemptible_tries,
+          hard_clip_reads = hard_clip_reads
       }
     }
 
@@ -232,7 +237,9 @@ workflow UnmappedBamToAlignedBam {
         ref_fasta_index = references.reference_fasta.ref_fasta_index,
         bqsr_scatter = bqsr_divisor,
         compression_level = compression_level,
-        preemptible_tries = papi_settings.agg_preemptible_tries
+        preemptible_tries = papi_settings.agg_preemptible_tries,
+        bin_base_qualities = bin_base_qualities,
+        somatic = somatic
     }
   }
 


### PR DESCRIPTION

Workflow has been updated to version 2.0 from the dsdepiplines repo. Changes are listed below: 

**Breaking changes to the structure of pipeline inputs.**
- Changes to the inputs included with the dna seq single sample references struct:
  - Removed 'fingerprint_genotypes_file' and 'fingerprint_genotypes_index' from bundle and made these optional pipeline inputs
  - Removed 'haplotype_scatter_count' and 'break_bands_at_multiples_of' from bundle and added these to a separate 'VariantCallingScatterSettings' struct
  - Added 'haplotype_database_file' to the references bundle as a non-optional file

**Additional changes**
- Renamed GermlineSingleSampleReferences to DNASeqSingleSampleReferences
- Updated shared tasks to support the new TargetedSomaticSingleSample pipeline