### PR TITLE
Bs update gatk readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gatk4-genome-processing-pipeline
 Workflows used for germline processing in whole genome sequence data.
 
+*- This repo will soon be archived, its new repository location will be [broadinstitute/warp](https://github.com/broadinstitute/warp/tree/develop/pipelines/broad/dna_seq/germline/single_sample/wgs)*
+
 ### WholeGenomeGermlineSingleSample :
 This WDL pipeline implements data pre-processing and initial variant calling (GVCF
 generation) according to the GATK Best Practices (June 2016) for germline SNP and
@@ -24,6 +26,7 @@ Indel discovery in human whole-genome sequencing data.
 
 ### Software version requirements :
 - GATK 4.0.10.1
+  - The Haplotypecaller WDL call provides the option to use GATK 3, which uses GATK 4.beta.5 for PrintReads and GATK 3.5 for Haplotypecaller. 
 - Picard 2.20.0-SNAPSHOT
 - Samtools 1.3.1
 - Python 2.7

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Indel discovery in human whole-genome sequencing data.
 - Samtools 1.3.1
 - Python 2.7
 - Cromwell version support 
-  - Successfully tested on v51
-  - Does not work on versions < v23 due to output syntax
+  - Successfully tested on v53
 
 ### Important Notes :
 - The provided JSON is a generic ready to use example template for the workflow. It is the user’s responsibility to correctly set the reference and resource variables for their own particular test case using the [GATK Tool and Tutorial Documentations](https://gatk.broadinstitute.org/hc/en-us/categories/360002310591).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Indel discovery in human whole-genome sequencing data.
 
 ### Software version requirements :
 - GATK 4.0.10.1
-  - The Haplotypecaller WDL call provides the option to use GATK 3, which uses GATK 4.beta.5 for PrintReads and GATK 3.5 for Haplotypecaller. 
+  - The Haplotypecaller call provides the option to use GATK 3, which uses GATK 4.beta.5 for PrintReads and GATK 3.5 for Haplotypecaller. 
 - Picard 2.20.0-SNAPSHOT
 - Samtools 1.3.1
 - Python 2.7
@@ -40,7 +40,7 @@ Indel discovery in human whole-genome sequencing data.
 - For help running workflows on the Google Cloud Platform or locally please
 view the following tutorial [(How to) Execute Workflows from the gatk-workflows Git Organization](https://gatk.broadinstitute.org/hc/en-us/articles/360035530952).
 - Please visit the [User Guide](https://gatk.broadinstitute.org/hc/en-us/categories/360002310591) site for further documentation on our workflows and tools.
-- Relevant reference and resources bundles can be accessed in [Resource Bundle](https://gatk.broadinstitute.org/hc/en-us/articles/360036212652).
+- Relevant reference and resources bundles can be accessed in [Resource Bundle](https://gatk.broadinstitute.org/hc/en-us/articles/360035890811).
 
 ### Contact Us :
 - The following material is provided by the Data Science Platforum group at the Broad Institute. Please direct any questions or concerns to one of our forum sites : [GATK](https://gatk.broadinstitute.org/hc/en-us/community/topics) or [Terra](https://support.terra.bio/hc/en-us/community/topics/360000500432).

--- a/WholeGenomeGermlineSingleSample.wdl
+++ b/WholeGenomeGermlineSingleSample.wdl
@@ -38,7 +38,7 @@ import "./structs/DNASeqStructs.wdl"
 # WORKFLOW DEFINITION
 workflow WholeGenomeGermlineSingleSample {
 
-  String pipeline_version = "2.0"
+  String pipeline_version = "2.1.0"
 
   input {
     SampleAndUnmappedBams sample_and_unmapped_bams
@@ -217,5 +217,8 @@ workflow WholeGenomeGermlineSingleSample {
 
     File output_vcf = BamToGvcf.output_vcf
     File output_vcf_index = BamToGvcf.output_vcf_index
+  }
+  meta {
+    allowNestedInputs: true
   }
 }

--- a/tasks/AggregatedBamQC.wdl
+++ b/tasks/AggregatedBamQC.wdl
@@ -106,4 +106,8 @@ input {
     File? fingerprint_summary_metrics = CheckFingerprint.summary_metrics
     File? fingerprint_detail_metrics = CheckFingerprint.detail_metrics
   }
+
+  meta {
+    allowNestedInputs: true
+  }
 }

--- a/tasks/BamToCram.wdl
+++ b/tasks/BamToCram.wdl
@@ -63,5 +63,8 @@ workflow BamToCram {
      File output_cram_md5 = ConvertToCram.output_cram_md5
      File validate_cram_file_report = ValidateCram.report
   }
+  meta {
+    allowNestedInputs: true
+  }
 }
 

--- a/tasks/SplitLargeReadGroup.wdl
+++ b/tasks/SplitLargeReadGroup.wdl
@@ -26,7 +26,6 @@ workflow SplitLargeReadGroup {
     File input_bam
 
     String bwa_commandline
-    String bwa_version
     String output_bam_basename
 
     # reference_fasta.ref_alt is the .alt file from bwa-kit
@@ -58,7 +57,6 @@ workflow SplitLargeReadGroup {
         bwa_commandline = bwa_commandline,
         output_bam_basename = current_name,
         reference_fasta = reference_fasta,
-        bwa_version = bwa_version,
         compression_level = compression_level,
         preemptible_tries = preemptible_tries,
         hard_clip_reads = hard_clip_reads
@@ -83,5 +81,8 @@ workflow SplitLargeReadGroup {
   }
   output {
     File aligned_bam = GatherMonolithicBamFile.output_bam
+  }
+  meta {
+    allowNestedInputs: true
   }
 }

--- a/tasks/UnmappedBamToAlignedBam.wdl
+++ b/tasks/UnmappedBamToAlignedBam.wdl
@@ -50,10 +50,6 @@ workflow UnmappedBamToAlignedBam {
 
   Int compression_level = 2
 
-  # Get the version of BWA to include in the PG record in the header of the BAM produced
-  # by MergeBamAlignment.
-  call Alignment.GetBwaVersion
-
   # Get the size of the standard reference files as well as the additional reference files needed for BWA
 
   # Align flowcell-level unmapped input bams in parallel
@@ -78,7 +74,6 @@ workflow UnmappedBamToAlignedBam {
         input:
           input_bam = unmapped_bam,
           bwa_commandline = bwa_commandline,
-          bwa_version = GetBwaVersion.bwa_version,
           output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
           reference_fasta = references.reference_fasta,
           compression_level = compression_level,
@@ -95,7 +90,6 @@ workflow UnmappedBamToAlignedBam {
           bwa_commandline = bwa_commandline,
           output_bam_basename = unmapped_bam_basename + ".aligned.unsorted",
           reference_fasta = references.reference_fasta,
-          bwa_version = GetBwaVersion.bwa_version,
           compression_level = compression_level,
           preemptible_tries = papi_settings.preemptible_tries,
           hard_clip_reads = hard_clip_reads
@@ -276,5 +270,8 @@ workflow UnmappedBamToAlignedBam {
 
     File output_bam = GatherBamFiles.output_bam
     File output_bam_index = GatherBamFiles.output_bam_index
+  }
+  meta {
+    allowNestedInputs: true
   }
 }

--- a/tasks/VariantCalling.wdl
+++ b/tasks/VariantCalling.wdl
@@ -153,6 +153,9 @@ workflow VariantCalling {
     File? bamout = MergeBamouts.output_bam
     File? bamout_index = MergeBamouts.output_bam_index
   }
+  meta {
+    allowNestedInputs: true
+  }
 }
 
 # This task is here because merging bamout files using Picard produces an error.


### PR DESCRIPTION
- Updated wdls to match dsde-pipeline version 2.1.0:
  * Added a meta section with 'allowNestedInputs' set to 'true' to allow the workflow to use with nested inputs with Cromwell 52.  (from 2.1.0)
  * Remove GetBWAVersion as a task and moved it to SamToFastqAndBwaMemAndMba. (from 2.0.1)
  
- Specified GATK version used in Readme
